### PR TITLE
Fix error on C# <9.0 and warning on .NET 5.0

### DIFF
--- a/src/libs/SkipLocalsInit/SkipLocalsInitAttribute.cs
+++ b/src/libs/SkipLocalsInit/SkipLocalsInitAttribute.cs
@@ -1,23 +1,24 @@
-﻿#if !NET6_0_OR_GREATER
+﻿#if !NET5_0_OR_GREATER 
 
-namespace System.Runtime.CompilerServices;
-
-/// <summary>
-/// Used to indicate to the compiler that the <c>.locals init</c> flag should not be set in method headers.
-/// </summary>
-/// <remarks>Internal copy of the .NET 5 attribute.</remarks>
-[global::System.AttributeUsage(
-    global::System.AttributeTargets.Module |
-    global::System.AttributeTargets.Class |
-    global::System.AttributeTargets.Struct |
-    global::System.AttributeTargets.Interface |
-    global::System.AttributeTargets.Constructor |
-    global::System.AttributeTargets.Method |
-    global::System.AttributeTargets.Property |
-    global::System.AttributeTargets.Event,
-    Inherited = false)]
-internal sealed class SkipLocalsInitAttribute : global::System.Attribute
+namespace System.Runtime.CompilerServices
 {
+    /// <summary>
+    /// Used to indicate to the compiler that the <c>.locals init</c> flag should not be set in method headers.
+    /// </summary>
+    /// <remarks>Internal copy of the .NET 5 attribute.</remarks>
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Module |
+        global::System.AttributeTargets.Class |
+        global::System.AttributeTargets.Struct |
+        global::System.AttributeTargets.Interface |
+        global::System.AttributeTargets.Constructor |
+        global::System.AttributeTargets.Method |
+        global::System.AttributeTargets.Property |
+        global::System.AttributeTargets.Event,
+        Inherited = false)]
+    internal sealed class SkipLocalsInitAttribute : global::System.Attribute
+    {
+    }
 }
 
 #endif


### PR DESCRIPTION
This is a cool package!

In order to use it with C# versions before 10.0 (and [`localsinit` suppression was introduced in C# 9.0](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/skip-localsinit)) we need to remove the file-scoped namespace. Otherwise the source will not compile:
```
/snip/snap/.nuget/packages/skiplocalsinit/1.0.0/build/SkipLocalsInitAttribute.cs(3,1): error CS8773: Feature 'file-scoped namespace' is not available in C# 9.0. Please use language version 10.0 or greater. [/snip/snap/skip.csproj]
```

In addition, this attribute already exists in .NET 5.0, so the preprocessor constant should be adjusted to remove the warning below (it works with the warning still).
```
/snip/snap/Class1.cs(8,10): warning CS0436: The type 'SkipLocalsInitAttribute' in '/snip/snap/.nuget/packages/skiplocalsinit/1.0.0/build/SkipLocalsInitAttribute.cs' conflicts with the imported type 'SkipLocalsInitAttribute' in 'System.Runtime, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. Using the type defined in '/snip/snap/.nuget/packages/skiplocalsinit/1.0.0/build/SkipLocalsInitAttribute.cs'. [/snip/snap/skip.csproj]
```